### PR TITLE
fix: added custom content feed algos

### DIFF
--- a/apollos-church-api/config.postgres.yml
+++ b/apollos-church-api/config.postgres.yml
@@ -100,20 +100,21 @@ ROCK_MAPPINGS:
 TABS:
   HOME:
     - algorithms:
-      - type: CONTENT_FEED
+      - type: BE_READY_CONTENT_FEED
         arguments:
           channelIds:
             - 2055
+          limit: 1
       type: HeroList
     - algorithms:
-      - type: CONTENT_FEED
+      - type: GET_SET_CONTENT_FEED
         arguments:
           channelIds:
             - 2056
           limit: 1
       type: HeroList
     - algorithms:
-      - type: CONTENT_FEED
+      - type: GO_SERVE_CONTENT_FEED
         arguments:
           channelIds:
             - 2060

--- a/apollos-church-api/src/data/ActionAlgorithms.js
+++ b/apollos-church-api/src/data/ActionAlgorithms.js
@@ -1,0 +1,92 @@
+import { ActionAlgorithm } from '@apollosproject/data-connector-rock';
+
+class dataSource extends ActionAlgorithm.dataSource {
+  ACTION_ALGORITHMS = {
+    ...this.ACTION_ALGORITHMS,
+    BE_READY_CONTENT_FEED: this.beReadyContentFeedAlgorithm.bind(this),
+    GET_SET_CONTENT_FEED: this.getSetContentFeedAlgorithm.bind(this),
+    GO_SERVE_CONTENT_FEED: this.goServeContentFeedAlgorithm.bind(this),
+  };
+
+  async contentFeedAlgorithm({ channelIds = [], limit = 20, skip = 0 } = {}) {
+    const { ContentItem } = this.context.dataSources;
+    const items = await ContentItem.getFromCategoryIds(channelIds, {
+      limit,
+      skip,
+    });
+    return items.map((item, i) => ({
+      id: `${item.id}${i}`,
+      title: item.title,
+      subtitle: item.contentChannel?.name,
+      relatedNode: item,
+      image: item.getCoverImage(),
+      action: 'READ_CONTENT',
+      summary: item.summary,
+    }));
+  }
+
+  async beReadyContentFeedAlgorithm({
+    channelIds = [],
+    limit = 1,
+    skip = 0,
+  } = {}) {
+    const { ContentItem } = this.context.dataSources;
+    const items = await ContentItem.getFromCategoryIds(channelIds, {
+      limit,
+      skip,
+    });
+    return items.map((item, i) => ({
+      id: `${item.id}${i}`,
+      title: item.title,
+      subtitle: 'Be Ready',
+      relatedNode: item,
+      image: null,
+      action: 'READ_CONTENT',
+      summary: item.summary,
+    }));
+  }
+
+  async getSetContentFeedAlgorithm({
+    channelIds = [],
+    limit = 1,
+    skip = 0,
+  } = {}) {
+    const { ContentItem } = this.context.dataSources;
+    const items = await ContentItem.getFromCategoryIds(channelIds, {
+      limit,
+      skip,
+    });
+    return items.map((item, i) => ({
+      id: `${item.id}${i}`,
+      title: item.title,
+      subtitle: 'Get Set',
+      relatedNode: item,
+      image: null,
+      action: 'READ_CONTENT',
+      summary: item.summary,
+    }));
+  }
+
+  async goServeContentFeedAlgorithm({
+    channelIds = [],
+    limit = 1,
+    skip = 0,
+  } = {}) {
+    const { ContentItem } = this.context.dataSources;
+    const items = await ContentItem.getFromCategoryIds(channelIds, {
+      limit,
+      skip,
+    });
+    return items.map((item, i) => ({
+      id: `${item.id}${i}`,
+      title: 'Find Your Next Service',
+      subtitle: 'Go Serve',
+      relatedNode: item,
+      image: null,
+      action: 'READ_CONTENT',
+      summary: item.summary,
+    }));
+  }
+}
+
+export { dataSource };

--- a/apollos-church-api/src/data/index.postgres.js
+++ b/apollos-church-api/src/data/index.postgres.js
@@ -52,12 +52,12 @@ import {
   ContentItem as PostgresContentItem,
   ContentItemsConnection,
   ContentItemCategory,
-  ActionAlgorithm as PostgresActionAlgorithm,
+  // ActionAlgorithm as PostgresActionAlgorithm,
   PrayerRequest as PostgresPrayerRequest,
 } from '@apollosproject/data-connector-postgres';
 
 import * as Theme from './theme';
-
+import * as PostgresActionAlgorithm from './ActionAlgorithms';
 // This modules ties together certain updates so they occurs in both Rock and Postgres.
 // Will be eliminated in the future through an enhancement to the Shovel
 import {


### PR DESCRIPTION
@redreceipt This isn't complete yet, but I want to get your opinion on this work. I have them setup as three different algorithms in this iteration for setting custom subtitles and eventually custom colors. Is there a different way to approach this that wouldn't require the basically same algorithm 3 times? I would assume so, but I am unsure how to do overrides on a content feed (to set the subtitle and background color based on theme).

https://user-images.githubusercontent.com/72768221/134412557-031f4858-fa87-48eb-817d-edfb72b2ed1d.mp4