### PR TITLE
chore: updated auth canary

### DIFF
--- a/apolloschurchapp/package.json
+++ b/apolloschurchapp/package.json
@@ -47,7 +47,7 @@
     "@apollosproject/config": "^2.34.0",
     "@apollosproject/react-native-airplay-btn": "^0.2.0",
     "@apollosproject/ui-analytics": "^2.34.0",
-    "@apollosproject/ui-auth": "^2.34.0",
+    "@apollosproject/ui-auth": "^2.35.1-canary.3",
     "@apollosproject/ui-connected": "^2.35.1-canary.0",
     "@apollosproject/ui-fragments": "^2.34.0",
     "@apollosproject/ui-htmlview": "^2.34.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -373,10 +373,10 @@
   dependencies:
     react-native-device-info "^4.0.1"
 
-"@apollosproject/ui-auth@^2.34.0":
-  version "2.34.0"
-  resolved "https://registry.yarnpkg.com/@apollosproject/ui-auth/-/ui-auth-2.34.0.tgz#0de9843f010da1efaae0cb674dbe78165b092f3e"
-  integrity sha512-798H/1hfE6XZej1ycbdb4HJFc8zd8bwqtOIKVUtfk6e+DNm68yadiaXeMnzgNxXg6QK7tRo7Ehc9dHOUhryxhA==
+"@apollosproject/ui-auth@^2.35.1-canary.3":
+  version "2.35.1-canary.3"
+  resolved "https://registry.yarnpkg.com/@apollosproject/ui-auth/-/ui-auth-2.35.1-canary.3.tgz#dec32010be93616160a5cf7369716aeaa1639662"
+  integrity sha512-ECc58DmEMkfgUsXzz1MmzvVqlsGWfjx0a+uJyuAgDgiapNALoy/bnopESQt363RQv9Pp2V+22s1nJMvTk6hidA==
   dependencies:
     formik "1.5.1"
     yup "^0.27.0"


### PR DESCRIPTION
This PR brings in a canary for auth so that privacy policy can show below login.

![Simulator Screen Shot - iPhone 11 - 2021-10-18 at 13 15 39](https://user-images.githubusercontent.com/72768221/137785153-b9421969-d8d0-4e8e-aaa4-dc6314e96794.png)
