### PR TITLE
fix: added inline logical and operator to sanitize location features

### DIFF
--- a/apolloschurchapp/src/ui/LocationFeatureConnected/EventInfoItem/index.js
+++ b/apolloschurchapp/src/ui/LocationFeatureConnected/EventInfoItem/index.js
@@ -45,8 +45,8 @@ const styles = StyleSheet.create({
   container: (theme) => ({
     flexDirection: 'row',
     padding: 8,
-    borderBottomColor: 'rgba(0,0,0,0.2)',
-    borderBottomWidth: 1,
+    borderTopColor: 'rgba(0,0,0,0.2)',
+    borderTopWidth: 1,
     minHeight: 60,
     alignItems: 'center',
     backgroundColor: theme.colors.paper,

--- a/apolloschurchapp/src/ui/LocationFeatureConnected/LocationFeature/index.js
+++ b/apolloschurchapp/src/ui/LocationFeatureConnected/LocationFeature/index.js
@@ -37,26 +37,16 @@ export default function LocationFeature({
           />
         </MapView>
       )}
-      {lat ? (
-        <EventInfoItem
-          onPress={() =>
-            openMap({
-              latitude: lat,
-              longitude: long,
-              query: address,
-            })
-          }
-          icon="pin"
-          title={name || address}
-          subtitle={name && address}
-        />
-      ) : (
-        <EventInfoItem
-          icon="pin"
-          title={name || address}
-          subtitle={name && address}
-        />
-      )}
+      <EventInfoItem
+        onPress={() =>
+          openMap({
+            query: address,
+          })
+        }
+        icon="pin"
+        title={name || address}
+        subtitle={name && address}
+      />
       {date && <EventInfoItem icon="time" title={date} />}
     </>
   );

--- a/apolloschurchapp/src/ui/LocationFeatureConnected/LocationFeature/index.js
+++ b/apolloschurchapp/src/ui/LocationFeatureConnected/LocationFeature/index.js
@@ -11,12 +11,12 @@ export default function LocationFeature({
   city,
   state,
   zip,
-  lat,
+  // lat,
   long,
   date,
 }) {
   const address = `${street}, ${city}, ${state} ${zip}`;
-
+  const lat = undefined;
   return (
     <>
       {lat && (
@@ -52,7 +52,6 @@ export default function LocationFeature({
         />
       ) : (
         <EventInfoItem
-          onPress={() => undefined}
           icon="pin"
           title={name || address}
           subtitle={name && address}

--- a/apolloschurchapp/src/ui/LocationFeatureConnected/LocationFeature/index.js
+++ b/apolloschurchapp/src/ui/LocationFeatureConnected/LocationFeature/index.js
@@ -11,12 +11,12 @@ export default function LocationFeature({
   city,
   state,
   zip,
-  // lat,
+  lat,
   long,
   date,
 }) {
   const address = `${street}, ${city}, ${state} ${zip}`;
-  const lat = undefined;
+
   return (
     <>
       {lat && (

--- a/apolloschurchapp/src/ui/LocationFeatureConnected/LocationFeature/index.js
+++ b/apolloschurchapp/src/ui/LocationFeatureConnected/LocationFeature/index.js
@@ -19,34 +19,45 @@ export default function LocationFeature({
 
   return (
     <>
-      <MapView
-        initialRegion={{
-          latitude: lat,
-          longitude: long,
-          latitudeDelta: 0.05,
-          longitudeDelta: 0.05,
-        }}
-        style={{ aspectRatio: 2 / 1 }}
-      >
-        <Marker
-          latitude={lat}
-          longitude={long}
-          onPress={undefined}
-          opacityStyle={undefined}
-        />
-      </MapView>
-      <EventInfoItem
-        onPress={() =>
-          openMap({
+      {lat && (
+        <MapView
+          initialRegion={{
             latitude: lat,
             longitude: long,
-            query: address,
-          })
-        }
-        icon="pin"
-        title={name || address}
-        subtitle={name && address}
-      />
+            latitudeDelta: 0.05,
+            longitudeDelta: 0.05,
+          }}
+          style={{ aspectRatio: 2 / 1 }}
+        >
+          <Marker
+            latitude={lat}
+            longitude={long}
+            onPress={undefined}
+            opacityStyle={undefined}
+          />
+        </MapView>
+      )}
+      {lat ? (
+        <EventInfoItem
+          onPress={() =>
+            openMap({
+              latitude: lat,
+              longitude: long,
+              query: address,
+            })
+          }
+          icon="pin"
+          title={name || address}
+          subtitle={name && address}
+        />
+      ) : (
+        <EventInfoItem
+          onPress={() => undefined}
+          icon="pin"
+          title={name || address}
+          subtitle={name && address}
+        />
+      )}
       {date && <EventInfoItem icon="time" title={date} />}
     </>
   );


### PR DESCRIPTION
This adds some logical operators to only display mapview and open the maps app if you actually get a geocoordinate from rock.
<img src="https://user-images.githubusercontent.com/72768221/138121411-3a3f541d-1696-4823-b679-2f22729bc607.png" width="50%">

