### PR TITLE
chore: removed background audio modes

### DIFF
--- a/apolloschurchapp/ios/GoDoGood/Info.plist
+++ b/apolloschurchapp/ios/GoDoGood/Info.plist
@@ -95,9 +95,7 @@
 		<string>NunitoSans-SemiBoldItalic.ttf</string>
 	</array>
 	<key>UIBackgroundModes</key>
-	<array>
-		<string>audio</string>
-	</array>
+	<array/>
 	<key>UILaunchStoryboardName</key>
 	<string>SplashScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>


### PR DESCRIPTION
This is to comply with an Apple request for approval. Removes background audio since they do not have any video or audio in their app.