### PR TITLE
fix: Go Tab - Newest to Oldest Algorithm

### DIFF
--- a/apollos-church-api/config.postgres.yml
+++ b/apollos-church-api/config.postgres.yml
@@ -183,10 +183,10 @@ TABS:
 
   PRAY: # Go
     - algorithms:
-        - type: CONTENT_FEED
+        - type: NEWEST_TO_OLDEST_CONTENT_FEED
           arguments:
             channelIds:
-              - 2057
+              - a4796c21-4603-4341-8044-f9d41c925362
       type: VerticalCardList
 
   STORIES:

--- a/apollos-church-api/src/data/ActionAlgorithm.js
+++ b/apollos-church-api/src/data/ActionAlgorithm.js
@@ -7,7 +7,12 @@ class dataSource extends ActionAlgorithm.dataSource {
   ACTION_ALGORITHMS = {
     ...this.ACTION_ALGORITHMS,
     COMPLETED_CONTENT_FEED: this.completedContentFeedAlgorithm.bind(this),
-    OLDEST_TO_NEWEST_CONTENT_FEED: this.oldestToNewestContentFeedAlgorithm.bind(this),
+    OLDEST_TO_NEWEST_CONTENT_FEED: this.oldestToNewestContentFeedAlgorithm.bind(
+      this
+    ),
+    NEWEST_TO_OLDEST_CONTENT_FEED: this.newestToOldestContentFeedAlgorithm.bind(
+      this
+    ),
     SERIES_ITEM_IN_PROGRESS: this.seriesItemInProgressAlgorithm.bind(this),
     OPEN_GO_TAB: this.openGoTabAlgorithm.bind(this),
   };
@@ -52,6 +57,36 @@ class dataSource extends ActionAlgorithm.dataSource {
         contentItemCategoryId: { [Op.in]: channelIds },
       },
       order: [['publishAt', 'ASC']],
+    });
+
+    return items.map((item, i) => ({
+      id: `${item.id}${i}`,
+      title: item.title,
+      subtitle: subtitle || item.contentChannel?.name,
+      relatedNode: item,
+      image: hasImage ? item.getCoverImage() : null,
+      action: 'READ_CONTENT',
+      summary: item.summary,
+    }));
+  }
+
+  async newestToOldestContentFeedAlgorithm({
+    subtitle = '',
+    channelIds = [],
+    limit = 20,
+    skip = 0,
+    hasImage = true,
+  } = {}) {
+    const { ContentItem } = this.context.dataSources;
+
+    // This is custom....normally it is sorted by DESC
+    const items = await ContentItem.model.findAll({
+      limit,
+      skip,
+      where: {
+        contentItemCategoryId: { [Op.in]: channelIds },
+      },
+      order: [['publishAt', 'DESC']],
     });
 
     return items.map((item, i) => ({


### PR DESCRIPTION
This is basically the same thing as @nlewis84's oldest to newest algorithm but backwards. We can refactor this to just one algorithm if need be.
<img width="330" alt="Screen Shot 2021-10-27 at 9 36 53 AM" src="https://user-images.githubusercontent.com/40962668/139076724-7414850a-215e-4bfd-b93a-b84753e6f6c9.png">
