### PR TITLE
feat: new query for series progression

### DIFF
--- a/apollos-church-api/src/data/ActionAlgorithm.js
+++ b/apollos-church-api/src/data/ActionAlgorithm.js
@@ -145,7 +145,7 @@ class dataSource extends ActionAlgorithm.dataSource {
           FROM
               content_item c
           WHERE
-              c.content_item_category_id = '8edb84c2-063a-45bf-b92e-845745edb57a'
+              c.content_item_category_id = '${categoryId}'
           ORDER BY
               (CASE
                     WHEN parent_id = '520871fb-feca-4f28-bfcc-cbdc26083472' THEN 1


### PR DESCRIPTION
## What does this PR do?
This PR tweaks the existing Series Progression query in order to return series items according to this priority:

- Uncompleted in these series, in this order (Jump, Dive, Ripple, and Reckless Faith)

## Future Improvements?
Series priority is currently hardwired in a case statement on lines 151-155 due to priority not coming through on the database, and could be potentially handled another way later on. Instead of simply pulling up the oldest content item that is uncompleted, it was necessary to go by series order because otherwise it would return consecutive items from differing series (due to publish_at date).

## How does this query work?
- Collects the current user's completed items
- Collects all the series items (for all series), and sorts it by `[Jump, Dive, Ripple, Reckless Faith]` then by `publish_at`
- LEFT JOINS these tables and searches for NULL (this returns only the uncompleted items for the current user)
- Displays the needed data

## How was this tested?
This was tested almost entirely using SQL queries in Postico. Here is a video of the progression working as intended when moving from the end of the Jump Series to the next uncompleted item in the Dive Series:

https://user-images.githubusercontent.com/72768221/139134671-4e5d24dd-5e71-4d29-b52e-20550ea2bc01.mp4



