### PR TITLE
fix: Go Tab Correct Channel ID

### DIFF
--- a/apollos-church-api/config.postgres.yml
+++ b/apollos-church-api/config.postgres.yml
@@ -186,7 +186,7 @@ TABS:
         - type: CONTENT_FEED
           arguments:
             channelIds:
-              - 2057
+              - a4796c21-4603-4341-8044-f9d41c925362
       type: VerticalCardList
 
   STORIES:


### PR DESCRIPTION
in the config.postgres.yml, channelId needs to be a postgres ID