### PR TITLE
chore: suggested follow id was corrected

### DIFF
--- a/apollos-church-api/config.postgres.yml
+++ b/apollos-church-api/config.postgres.yml
@@ -59,7 +59,7 @@ CLOUDINARY:
   URL: ${CLOUDINARY_URL}
 SUGGESTED_FOLLOWS:
   -
-    id: 17d09e50-7bb2-4997-af06-9fd63edadc09 # Matt Massey
+    id: 6379020d-d0a9-45a2-9fe0-7dfdb482daf3 # Matt Massey
   -
     id: 429064f1-ef68-4f50-bcb5-63a2034f83ba # JR Cifani
   -


### PR DESCRIPTION
Matt Massey suggested follow ID was incorrect and this PR fixes that mistake.

![Screen Shot 2021-11-12 at 4 31 57 PM](https://user-images.githubusercontent.com/72768221/141555359-834161f4-262b-42e7-8285-940e3bc82273.png)
