### PR TITLE
chore: bump version to 1.0.4

### DIFF
--- a/apolloschurchapp/android/app/build.gradle
+++ b/apolloschurchapp/android/app/build.gradle
@@ -156,7 +156,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
-        versionName "1.0.3"
+        versionName "1.0.4"
         ndk {
             abiFilters "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
         }

--- a/apolloschurchapp/ios/GoDoGood/Info.plist
+++ b/apolloschurchapp/ios/GoDoGood/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.3</string>
+	<string>1.0.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/apolloschurchapp/ios/OneSignalNotificationServiceExtension/Info.plist
+++ b/apolloschurchapp/ios/OneSignalNotificationServiceExtension/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.3</string>
+	<string>1.0.4</string>
 	<key>CFBundleVersion</key>
 	<string>55</string>
 	<key>NSExtension</key>

--- a/apolloschurchapp/package.json
+++ b/apolloschurchapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "GoDoGood",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "engines": {
     "node": ">=14"


### PR DESCRIPTION
This PR bumps version number to fix deploys.

# The Issue

<img width="729" alt="Screen Shot 2021-11-15 at 2 59 16 PM" src="https://user-images.githubusercontent.com/72768221/141853008-ff5f480e-eef4-438f-9732-78a803d4298d.png">
