### PR TITLE
chore: switched text and image in onboarding

### DIFF
--- a/apolloschurchapp/src/ui/Onboarding/Slides/BeReady.js
+++ b/apolloschurchapp/src/ui/Onboarding/Slides/BeReady.js
@@ -11,6 +11,7 @@ const Background = withTheme(({ theme }) => ({
     height: '100%',
     width: '100%',
     position: 'absolute',
+    top: '20%',
   },
   source:
     theme.type === 'light'
@@ -19,7 +20,7 @@ const Background = withTheme(({ theme }) => ({
 }))(Image);
 
 const StyledSlideContent = styled({
-  marginTop: '66%',
+  height: '33%',
 })(SlideContent);
 
 const Features = memo(({ firstName, description, ...props }) => (

--- a/apolloschurchapp/src/ui/Onboarding/Slides/GetSet.js
+++ b/apolloschurchapp/src/ui/Onboarding/Slides/GetSet.js
@@ -11,6 +11,7 @@ const Background = withTheme(({ theme }) => ({
     height: '100%',
     width: '100%',
     position: 'absolute',
+    top: '20%',
   },
   source:
     theme.type === 'light'
@@ -19,7 +20,7 @@ const Background = withTheme(({ theme }) => ({
 }))(Image);
 
 const StyledSlideContent = styled({
-  marginTop: '66%',
+  height: '33%',
 })(SlideContent);
 
 const Features = memo(({ firstName, description, ...props }) => (

--- a/apolloschurchapp/src/ui/Onboarding/Slides/GoServe.js
+++ b/apolloschurchapp/src/ui/Onboarding/Slides/GoServe.js
@@ -11,6 +11,7 @@ const Background = withTheme(({ theme }) => ({
     height: '100%',
     width: '100%',
     position: 'absolute',
+    top: '20%',
   },
   source:
     theme.type === 'light'
@@ -19,7 +20,7 @@ const Background = withTheme(({ theme }) => ({
 }))(Image);
 
 const StyledSlideContent = styled({
-  marginTop: '66%',
+  height: '33%',
 })(SlideContent);
 
 const Features = memo(({ firstName, description, ...props }) => (

--- a/apolloschurchapp/src/ui/Onboarding/Slides/Pray.js
+++ b/apolloschurchapp/src/ui/Onboarding/Slides/Pray.js
@@ -11,6 +11,7 @@ const Background = withTheme(({ theme }) => ({
     height: '100%',
     width: '100%',
     position: 'absolute',
+    top: '20%',
   },
   source:
     theme.type === 'light'
@@ -19,7 +20,7 @@ const Background = withTheme(({ theme }) => ({
 }))(Image);
 
 const StyledSlideContent = styled({
-  marginTop: '66%',
+  height: '33%',
 })(SlideContent);
 
 const Features = memo(({ firstName, description, ...props }) => (


### PR DESCRIPTION
This PR puts the text in the top 3rd and the image below that.

https://user-images.githubusercontent.com/72768221/145459343-462f577e-d7c8-4504-91f5-b18e723f0fc8.mp4

