### PR TITLE
chore: update fetch policy for location features

### DIFF
--- a/apolloschurchapp/src/ui/LocationFeatureConnected/index.js
+++ b/apolloschurchapp/src/ui/LocationFeatureConnected/index.js
@@ -9,7 +9,7 @@ export default function LocationFeatureConnected({ nodeId }) {
     variables: {
       nodeId,
     },
-    fetchPolicy: 'cache-and-network',
+    fetchPolicy: 'network-only',
   });
 
   if (data?.getLocationFeature) {


### PR DESCRIPTION
This is in regards to this issue reported by the client:

https://3.basecamp.com/3926363/buckets/20463299/todos/4451200821

@redreceipt What do you think about this? Do you think this could fix the issue? Any reasons why we shouldn't change this?